### PR TITLE
Fix: extension method "Abs" outputs malformed URLs

### DIFF
--- a/Mvc.Mailer.Test/ExtensionMethods/UrlHelperExtensionsTest.cs
+++ b/Mvc.Mailer.Test/ExtensionMethods/UrlHelperExtensionsTest.cs
@@ -54,6 +54,12 @@ namespace Mvc.Mailer.Test
         }
 
         [Test]
+        public void Abs_with_encoded_params_should_keep_encoding()
+        {
+            Assert.AreEqual("http://example.com:8080/?param=encoded%20value", _urlHelper.Abs("/?param=encoded%20value"));
+        }
+
+        [Test]
         public void Abs_with_config_should_use_the_base_url_from_the_config()
         {
             ConfigurationManager.AppSettings[UrlHelperExtensions.BASE_URL_KEY] = "http://my:666";

--- a/Mvc.Mailer/ExtensionMethods/UrlHelperExtensions.cs
+++ b/Mvc.Mailer/ExtensionMethods/UrlHelperExtensions.cs
@@ -26,7 +26,7 @@ namespace Mvc.Mailer
             Uri combinedUri;
             if (Uri.TryCreate(BaseUrl(urlHelper), relativeOrAbsoluteUrl, out combinedUri))
             {
-                return combinedUri.ToString();
+                return combinedUri.AbsoluteUri;
             }
 
             throw new Exception(string.Format("Could not create absolute url for {0} using baseUri{0}", relativeOrAbsoluteUrl, BaseUrl(urlHelper)));


### PR DESCRIPTION
Use "AbsoluteUri" instead of "ToString()" to avoid removing the escaping from query string parameters.

This means that a URL like "/page.html?query=parameter%20value" will be output with the %20 intact, rather than using a space.

Thanks for the great package, a joy to use :)
