### PR TITLE
Removes exception re-throw in StringResult to preserve stack-trace to help debugging errors in views

### DIFF
--- a/Mvc.Mailer/StringResult.cs
+++ b/Mvc.Mailer/StringResult.cs
@@ -45,16 +45,10 @@ namespace Mvc.Mailer
             {
                 ExecuteResult(context);
             }
-            catch(Exception ex)
-            {
-                throw ex;
-            }
             finally{
                 //restore the controller name
                 context.RouteData.Values["controller"] = controllerName;
             }
-
-
         }
 
         public override void ExecuteResult(ControllerContext context)


### PR DESCRIPTION
I had some issues with errors in my email view and it was proving difficult to debug them because the stack trace was re-written by a "throw ex;" in StringResult.
