### PR TITLE
Let the view set the subject

### DIFF
--- a/Mvc.Mailer/StringResult.cs
+++ b/Mvc.Mailer/StringResult.cs
@@ -20,6 +20,7 @@ namespace Mvc.Mailer {
         /// Contains the output after compiling the view and putting in the values
         /// </summary>
         public string Output { get; private set; }
+        public ViewContext ViewContext { get; private set; }
 
         public virtual void ExecuteResult(ControllerContext context, string mailerName) {
             //remember the controller name
@@ -51,8 +52,8 @@ namespace Mvc.Mailer {
             var stringBuilder = new StringBuilder();
             TextWriter writer = new StringWriter(stringBuilder);
 
-            var viewContext = new ViewContext(context, View, ViewData, TempData, writer);
-            View.Render(viewContext, writer);
+            ViewContext = new ViewContext(context, View, ViewData, TempData, writer);
+            View.Render(ViewContext, writer);
 
             Output = stringBuilder.ToString();
         }


### PR DESCRIPTION
I needed to specify the subject of the email in the view rather than hardcoding it in the code or store it separately. This can be extended so more data can come from view such as recipients, reply tos, html body, etc.

Here's the usage:

@{
    TempData["Subject"] = string.Format("A new post has been added to {0}", Model.Name);
}
