### PR TITLE
Added null check for CurrentHttpContext

### DIFF
--- a/Mvc.Mailer/MailerBase.cs
+++ b/Mvc.Mailer/MailerBase.cs
@@ -245,7 +245,10 @@ namespace Mvc.Mailer {
         }
 
         private void CreateControllerContext() {
-            var routeData = RouteTable.Routes.GetRouteData(CurrentHttpContext);
+            if (CurrentHttpContext == null) {
+                throw new ArgumentNullException("CurrentHttpContext", "CurrentHttpContext cannot be null");
+            }
+			var routeData = RouteTable.Routes.GetRouteData(CurrentHttpContext);
             ControllerContext = new ControllerContext(CurrentHttpContext, routeData, this);
         }
 


### PR DESCRIPTION
This was a small thing that bit me when I first tried to use MvcMailer.  I had not passed in an HttpContext and it exploded (as it should), but it gave me a object reference error.  I just added a check for to throw a specific exception message if it's null instead of throwing a generic object reference exception
