### PR TITLE
Updated to latest MVC v5.2.3

### DIFF
--- a/Mvc.Mailer.Test/Mvc.Mailer.Test.csproj
+++ b/Mvc.Mailer.Test/Mvc.Mailer.Test.csproj
@@ -47,9 +47,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\lib\MVC4\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Mvc.Mailer/Mvc.Mailer.csproj
+++ b/Mvc.Mailer/Mvc.Mailer.csproj
@@ -38,7 +38,10 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -84,8 +87,8 @@
     <None Include="NuGet\MvcMailer.nuspec">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>IF NOT EXIST "$(ProjectDir)NuGet\input\lib\45" md "$(ProjectDir)NuGet\input\lib\45"

--- a/Mvc.Mailer/packages.config
+++ b/Mvc.Mailer/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
-  <package id="Moq" version="4.0.10827" targetFramework="net4" />
-  <package id="NUnit" version="2.6.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
As MVC 5 is not served from GAC, MVC 5 nuget package is added, It was throwing exception in Azure cloud service due to older MVC reference "Azure Role does not start, Could not load file or assembly ‘System.Web.Mvc, Version=4.0.0.0".
